### PR TITLE
Simplify examples by updating to new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ test,1,24
 "hello world",2,48
 ```
 ```php
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 
 $stream = new Decoder($stdin);
 
@@ -261,7 +261,7 @@ test,1
 "hello world",2
 ```
 ```php
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 
 $stream = new AssocDecoder($stdin);
 
@@ -304,7 +304,7 @@ and accepts its data through the same interface, but handles any data as complet
 CSV elements instead of just chunks of strings:
 
 ```php
-$stdout = new WritableResourceStream(STDOUT, $loop);
+$stdout = new WritableResourceStream(STDOUT);
 
 $stream = new Encoder($stdout);
 

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,19 @@
             "email": "christian@clue.engineering"
         }
     ],
+    "require": {
+        "php": ">=5.3",
+        "react/stream": "^1.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
+        "react/child-process": "^0.6.3",
+        "react/event-loop": "^1.2"
+    },
     "autoload": {
         "psr-4": { "Clue\\React\\Csv\\": "src/" }
     },
     "autoload-dev": {
         "psr-4": { "Clue\\Tests\\React\\Csv\\": "tests/" }
-    },
-    "require": {
-        "php": ">=5.3",
-        "react/stream": "^1.0 || ^0.7 || ^0.6"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
-        "react/child-process": "^0.6",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
     }
 }

--- a/examples/01-count.php
+++ b/examples/01-count.php
@@ -3,17 +3,15 @@
 // $ php examples/01-count.php < examples/users.csv
 
 use Clue\React\Csv\AssocDecoder;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $exit = 0;
-$in = new ReadableResourceStream(STDIN, $loop);
-$info = new WritableResourceStream(STDERR, $loop);
+$in = new ReadableResourceStream(STDIN);
+$info = new WritableResourceStream(STDERR);
 
 $delimiter = isset($argv[1]) ? $argv[1] : ',';
 
@@ -37,6 +35,6 @@ $info->write('You can pipe/write a valid CSV stream to STDIN' . PHP_EOL);
 $info->write('The resulting number of records (rows minus header row) will be printed to STDOUT' . PHP_EOL);
 $info->write('Invalid CSV will raise an error on STDERR and exit with code 1' . PHP_EOL);
 
-$loop->run();
+Loop::run();
 
 exit($exit);

--- a/examples/02-validate.php
+++ b/examples/02-validate.php
@@ -4,18 +4,16 @@
 
 use Clue\React\Csv\Decoder;
 use Clue\React\Csv\Encoder;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $exit = 0;
-$in = new ReadableResourceStream(STDIN, $loop);
-$out = new WritableResourceStream(STDOUT, $loop);
-$info = new WritableResourceStream(STDERR, $loop);
+$in = new ReadableResourceStream(STDIN);
+$out = new WritableResourceStream(STDOUT);
+$info = new WritableResourceStream(STDERR);
 
 $delimiter = isset($argv[1]) ? $argv[1] : ',';
 
@@ -32,6 +30,6 @@ $info->write('You can pipe/write a valid CSV stream to STDIN' . PHP_EOL);
 $info->write('Valid CSV will be forwarded to STDOUT' . PHP_EOL);
 $info->write('Invalid CSV will raise an error on STDERR and exit with code 1' . PHP_EOL);
 
-$loop->run();
+Loop::run();
 
 exit($exit);

--- a/examples/11-csv2ndjson.php
+++ b/examples/11-csv2ndjson.php
@@ -4,19 +4,17 @@
 // see also https://github.com/clue/reactphp-ndjson
 
 use Clue\React\Csv\AssocDecoder;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $exit = 0;
-$in = new ReadableResourceStream(STDIN, $loop);
-$out = new WritableResourceStream(STDOUT, $loop);
-$info = new WritableResourceStream(STDERR, $loop);
+$in = new ReadableResourceStream(STDIN);
+$out = new WritableResourceStream(STDOUT);
+$info = new WritableResourceStream(STDERR);
 
 $delimiter = isset($argv[1]) ? $argv[1] : ',';
 
@@ -41,6 +39,6 @@ $info->write('You can pipe/write a valid CSV stream to STDIN' . PHP_EOL);
 $info->write('Valid NDJSON (Newline-Delimited JSON) will be forwarded to STDOUT' . PHP_EOL);
 $info->write('Invalid CSV will raise an error on STDERR and exit with code 1' . PHP_EOL);
 
-$loop->run();
+Loop::run();
 
 exit($exit);

--- a/examples/12-csv2tsv.php
+++ b/examples/12-csv2tsv.php
@@ -4,19 +4,17 @@
 // see also https://github.com/clue/reactphp-tsv
 
 use Clue\React\Csv\Decoder;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
 use React\Stream\ThroughStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $exit = 0;
-$in = new ReadableResourceStream(STDIN, $loop);
-$out = new WritableResourceStream(STDOUT, $loop);
-$info = new WritableResourceStream(STDERR, $loop);
+$in = new ReadableResourceStream(STDIN);
+$out = new WritableResourceStream(STDOUT);
+$info = new WritableResourceStream(STDERR);
 
 $delimiter = isset($argv[1]) ? $argv[1] : ',';
 
@@ -50,6 +48,6 @@ $info->write('You can pipe/write a valid CSV stream to STDIN' . PHP_EOL);
 $info->write('Valid TSV (Tab-Separated Values) will be forwarded to STDOUT' . PHP_EOL);
 $info->write('Invalid CSV will raise an error on STDERR and exit with code 1' . PHP_EOL);
 
-$loop->run();
+Loop::run();
 
 exit($exit);

--- a/examples/91-benchmark-count.php
+++ b/examples/91-benchmark-count.php
@@ -11,7 +11,7 @@
 // $ php examples/91-benchmark-count.php < IRAhandle_tweets_1.csv
 
 use Clue\React\Csv\AssocDecoder;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -20,8 +20,7 @@ if (extension_loaded('xdebug')) {
     echo 'NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL;
 }
 
-$loop = Factory::create();
-$decoder = new AssocDecoder(new ReadableResourceStream(STDIN, $loop));
+$decoder = new AssocDecoder(new ReadableResourceStream(STDIN));
 
 $count = 0;
 $decoder->on('data', function () use (&$count) {
@@ -29,15 +28,13 @@ $decoder->on('data', function () use (&$count) {
 });
 
 $start = microtime(true);
-$report = $loop->addPeriodicTimer(0.05, function () use (&$count, $start) {
+$report = Loop::addPeriodicTimer(0.05, function () use (&$count, $start) {
     printf("\r%d records in %0.3fs...", $count, microtime(true) - $start);
 });
 
-$decoder->on('close', function () use (&$count, $report, $loop, $start) {
+$decoder->on('close', function () use (&$count, $report, $start) {
     $now = microtime(true);
-    $loop->cancelTimer($report);
+    Loop::cancelTimer($report);
 
     printf("\r%d records in %0.3fs => %d records/s\n", $count, $now - $start, $count / ($now - $start));
 });
-
-$loop->run();


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).
Builds on top of reactphp/event-loop#229, reactphp/event-loop#232, reactphp/stream#159 and https://github.com/reactphp/child-process/pull/87