### PR TITLE
Support custom EOL character when encoding CSV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/README.md
+++ b/README.md
@@ -317,9 +317,10 @@ test,1,24
 ```
 
 The `Encoder` supports the same optional parameters as the underlying
-[`fputcsv()`](https://www.php.net/fputcsv) function.
+[`fputcsv()`](https://www.php.net/manual/en/function.fputcsv.php) function.
 This means that, by default, CSV fields will be delimited by a comma (`,`), will
-use a quote enclosure character (`"`) and a backslash escape character (`\`).
+use a quote enclosure character (`"`), a backslash escape character (`\`), and
+a Unix-style EOL (`\n` or `LF`).
 This behavior can be controlled through the optional constructor parameters:
 
 ```php
@@ -385,7 +386,7 @@ See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 This project aims to run on any platform and thus does not require any PHP
 extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
-It's *highly recommended to use PHP 7+* for this project.
+It's *highly recommended to use the latest supported PHP version PHP 7+* for this project.
 
 ## Tests
 

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -44,9 +44,6 @@ class EncoderTest extends TestCase
         $this->encoder->write(array('hello', 'world'));
     }
 
-    /**
-     * @requires PHP 8.1
-     */
     public function testWriteArrayWithCustomEolForWindows()
     {
         $this->output = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -44,6 +44,20 @@ class EncoderTest extends TestCase
         $this->encoder->write(array('hello', 'world'));
     }
 
+    /**
+     * @requires PHP 8.1
+     */
+    public function testWriteArrayWithCustomEolForWindows()
+    {
+        $this->output = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $this->output->expects($this->once())->method('isWritable')->willReturn(true);
+        $this->encoder = new Encoder($this->output, ',', '"', '\\', "\r\n");
+
+        $this->output->expects($this->once())->method('write')->with("hello,world\r\n");
+
+        $this->encoder->write(array('hello', 'world'));
+    }
+
     public function testWriteArrayTwiceWillSeparateWithNewlineAfterEachWrite()
     {
         $this->output = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();


### PR DESCRIPTION
This changeset adds support for specifying a custom EOL character. This can be useful when creating a CSV file using the `Encoder` for Windows using the `CRLF` sequence (`\r\n`) like this:

```php
$encoder = new Clue\React\Csv\Encoder($this->output, ',', '"', '\\', "\r\n");
```

This is supported natively by PHP as of PHP 8.1, but this PR also implements the same feature for all supported PHP versions.

Refs https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.standard