### PR TITLE
Fix legacy HHVM build by downgrading Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,6 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
+      - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clue/reactphp-csv
 
-[![CI status](https://github.com/clue/reactphp-csv/workflows/CI/badge.svg)](https://github.com/clue/reactphp-csv/actions)
+[![CI status](https://github.com/clue/reactphp-csv/actions/workflows/ci.yml/badge.svg)](https://github.com/clue/reactphp-csv/actions)
 [![installs on Packagist](https://img.shields.io/packagist/dt/clue/reactphp-csv?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/clue/reactphp-csv)
 
 Streaming CSV (Comma-Separated Values or Character-Separated Values) parser and encoder for [ReactPHP](https://reactphp.org/).


### PR DESCRIPTION
Builds on top of the work done by @clue and the discussion inside reactphp/socket#289.

I also updated the path for the CI badge.